### PR TITLE
Pipeline stages

### DIFF
--- a/src/balls/config.clj
+++ b/src/balls/config.clj
@@ -56,3 +56,5 @@
 			override-url
 			override-red-alert-threshold
 			override-glitch-effect-threshold))
+
+(defn stage-delimiter [] (or (config-attr :stage-delimiter) "-"))

--- a/src/balls/data/go.clj
+++ b/src/balls/data/go.clj
@@ -67,7 +67,7 @@
 (defn find-names
 	[{:keys [url select exclude]}]
 	(if-not (empty? url)
-		{:names (->> (interesting-projects url select exclude) (map :name))}
+		{:names (->> (interesting-projects url select exclude) (map :name) distinct)}
 		{:name []}))
 
 (defn get-filtered-projects


### PR DESCRIPTION
A couple of changes to support adding the stage to the pipeline name for Go CI

- adding stage to pipeline name for both Snap and Go CI servers
- allowing configuration of delimiter for pipeline name and stage (defaults to '-', can be overriden in config.json. (future-fact "can change through UI"))
- calls to /filternames now get distinct pipeline names to remove duplicate of pipeline/stage/job matches in Snap and Go